### PR TITLE
search: Add new search command

### DIFF
--- a/src/Deathstar.Canteen.Tests/Units/CommandFactoryTests.cs
+++ b/src/Deathstar.Canteen.Tests/Units/CommandFactoryTests.cs
@@ -76,6 +76,19 @@ namespace Deathstar.Canteen.Tests.Units
 		}
 
 		[Fact]
+		public void TheCommandFactoryShouldConstrucSearchCommandWhenSearchCommandNameIsProvided()
+		{
+			// Arrange
+			var factory = new CommandFactory( MongoHelper.Client );
+
+			// Act
+			ICommand command = factory.GetCommand( new CommandRequest( "search" ) );
+
+			// Assert
+			Assert.IsType<SearchCommand>( command );
+		}
+
+		[Fact]
 		public void TheCommandFactoryShouldConstructDayAfterTomorrowCommandWhenDayAfterTomorrowCommandNameIsProvided()
 		{
 			// Arrange

--- a/src/Deathstar.Canteen.Tests/Units/HelpCommandTests.cs
+++ b/src/Deathstar.Canteen.Tests/Units/HelpCommandTests.cs
@@ -114,6 +114,7 @@ namespace Deathstar.Canteen.Tests.Units
 				+ $"  *tomorrow*{Environment.NewLine}"
 				+ $"  *dayaftertomorrow*{Environment.NewLine}"
 				+ $"  *next*{Environment.NewLine}"
+				+ $"  *search*{Environment.NewLine}"
 				+ $"  *add*{Environment.NewLine}"
 				+ $"  *clear*{Environment.NewLine}"
 				+ $"  *import*{Environment.NewLine}"
@@ -127,6 +128,20 @@ namespace Deathstar.Canteen.Tests.Units
 
 			// Assert
 			Assert.Equal( generalHelpText, response );
+		}
+
+		[Fact]
+		public async Task TheHandleMethodWithSearchCommandNameShouldReturnDetailedHelpMessage()
+		{
+			// Arrange
+			var command = new HelpCommand( "search", MongoHelper.Client );
+
+			// Act
+			string response = await command.HandleAsync();
+
+			// Assert
+			Assert.Equal( $"The *search* command will query future meals and displays the found menus.{Environment.NewLine}{Environment.NewLine}Example: `search Foobar`",
+				response );
 		}
 
 		[Fact]
@@ -178,6 +193,7 @@ namespace Deathstar.Canteen.Tests.Units
 				+ $"  *tomorrow*{Environment.NewLine}"
 				+ $"  *dayaftertomorrow*{Environment.NewLine}"
 				+ $"  *next*{Environment.NewLine}"
+				+ $"  *search*{Environment.NewLine}"
 				+ $"  *add*{Environment.NewLine}"
 				+ $"  *clear*{Environment.NewLine}"
 				+ $"  *import*{Environment.NewLine}"

--- a/src/Deathstar.Canteen.Tests/Units/SearchCommandTests.cs
+++ b/src/Deathstar.Canteen.Tests/Units/SearchCommandTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Threading.Tasks;
+using Deathstar.Canteen.Commands;
+using Deathstar.Canteen.Persistence;
+using Deathstar.Canteen.Tests.Helpers;
+using Xunit;
+
+namespace Deathstar.Canteen.Tests.Units
+{
+	public class SearchCommandTests
+	{
+		public SearchCommandTests() => MongoHelper.Clear();
+
+		[Fact]
+		public async Task TheHandleMethodShouldOnlyReturnFromToday()
+		{
+			// Arrange
+			MongoHelper.Collection.InsertMany( new[]
+			{
+				new Menu
+				{
+					Date = DateTime.Today.ToString( "yyyyMMdd" ),
+					Meals = new[] { "Foo" }
+				},
+				new Menu
+				{
+					Date = DateTime.Today.AddDays( -1 ).ToString( "yyyyMMdd" ),
+					Meals = new[] { "Foo" }
+				}
+			} );
+			var command = new SearchCommand( "Foo", MongoHelper.Client );
+
+			// Act
+			string response = await command.HandleAsync();
+
+			// Assert
+			Assert.Equal( $"On *{DateTime.Today:dd.MM.yyyy}* the meals are:{Environment.NewLine}1. Foo", response );
+		}
+
+		[Fact]
+		public async Task TheHandleMethodShouldOnlyReturnQueriedDays()
+		{
+			// Arrange
+			MongoHelper.Collection.InsertMany( new[]
+			{
+				new Menu
+				{
+					Date = DateTime.Today.ToString( "yyyyMMdd" ),
+					Meals = new[] { "Foo" }
+				},
+				new Menu
+				{
+					Date = DateTime.Today.AddDays( 1 ).ToString( "yyyyMMdd" ),
+					Meals = new[] { "Bar" }
+				}
+			} );
+			var command = new SearchCommand( "Foo", MongoHelper.Client );
+
+			// Act
+			string response = await command.HandleAsync();
+
+			// Assert
+			Assert.Equal( $"On *{DateTime.Today:dd.MM.yyyy}* the meals are:{Environment.NewLine}1. Foo", response );
+		}
+
+		[Fact]
+		public async Task TheHandleMethodShouldOnlyReturnResultsSmallerThanTen()
+		{
+			// Arrange
+			for( int i = 1; i < 12; i++ )
+			{
+				MongoHelper.Collection.InsertOne( new Menu
+				{
+					Date = DateTime.Today.AddDays( i ).ToString( "yyyyMMdd" ),
+					Meals = new[] { "Foo" }
+				} );
+			}
+
+			var command = new SearchCommand( "Foo", MongoHelper.Client );
+
+			// Act
+			string response = await command.HandleAsync();
+
+			// Assert
+			Assert.Equal( "I found more than 10 menus. Please be more precise.", response );
+		}
+
+		[Fact]
+		public async Task TheHandleMethodShouldReturnNoticeAboutInvalidCommandArguments()
+		{
+			// Arrange
+			var command = new SearchCommand( "", MongoHelper.Client );
+
+			// Act
+			string response = await command.HandleAsync();
+
+			// Assert
+			Assert.Equal( "You need to provide some valid input.", response );
+		}
+
+		[Fact]
+		public async Task TheHandleMethodShouldReturnNoticeAboutMissingCommandArguments()
+		{
+			// Arrange
+			var command = new SearchCommand( null, MongoHelper.Client );
+
+			// Act
+			string response = await command.HandleAsync();
+
+			// Assert
+			Assert.Equal( "You need to provide some valid input.", response );
+		}
+
+		[Fact]
+		public async Task TheHandleMethodShouldReturnNoticeWhenNoDataWasFound()
+		{
+			// Arrange
+			var command = new SearchCommand( "foo", MongoHelper.Client );
+
+			// Act
+			string response = await command.HandleAsync();
+
+			// Assert
+			Assert.Equal( "I found nothing.", response );
+		}
+	}
+}

--- a/src/Deathstar.Canteen/CommandFactory.cs
+++ b/src/Deathstar.Canteen/CommandFactory.cs
@@ -32,6 +32,9 @@ namespace Deathstar.Canteen
 				case "next":
 					return new NextCommand( commandRequest.Arguments, MongoClient );
 
+				case "search":
+					return new SearchCommand( commandRequest.Arguments, MongoClient );
+
 				case "add":
 					return new AddCommand( commandRequest.Arguments, MongoClient );
 

--- a/src/Deathstar.Canteen/Commands/HelpCommand.cs
+++ b/src/Deathstar.Canteen/Commands/HelpCommand.cs
@@ -16,6 +16,7 @@ namespace Deathstar.Canteen.Commands
 			"tomorrow",
 			"dayaftertomorrow",
 			"next",
+			"search",
 			"add",
 			"clear",
 			"import",
@@ -50,6 +51,12 @@ namespace Deathstar.Canteen.Commands
 						+ Environment.NewLine
 						+ Environment.NewLine
 						+ "Example: `next 5`";
+
+				case "search":
+					return "The *search* command will query future meals and displays the found menus."
+						+ Environment.NewLine
+						+ Environment.NewLine
+						+ "Example: `search Foobar`";
 
 				case "add":
 					return "The *add* command can be used to add something to the menu."

--- a/src/Deathstar.Canteen/Commands/SearchCommand.cs
+++ b/src/Deathstar.Canteen/Commands/SearchCommand.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Deathstar.Canteen.Commands.Abstractions;
+using Deathstar.Canteen.Persistence;
+using MongoDB.Driver;
+
+namespace Deathstar.Canteen.Commands
+{
+	public class SearchCommand : Command
+	{
+		private Regex Regex { get; } = new Regex( @"\w[\w\s]+", RegexOptions.Compiled );
+
+		public SearchCommand( string arguments, IMongoClient mongoClient ) : base( arguments, mongoClient ) { }
+
+		public override async Task<string> HandleAsync()
+		{
+			if( !Regex.IsMatch( Arguments ?? string.Empty ) )
+				return "You need to provide some valid input.";
+
+			IAsyncCursor<Menu> cursor = await MongoCollection.FindAsync( $"{{Meals: {{ $regex: '.*{Arguments}.*' }}, Date: {{ $gte: '{DateTime.Today:yyyyMMdd}' }} }}" );
+			List<Menu> menus = await cursor.ToListAsync();
+
+			if( menus == null || menus.Count == 0 )
+				return "I found nothing.";
+
+			if( menus.Count > 10 )
+				return "I found more than 10 menus. Please be more precise.";
+
+			string response = string.Empty;
+
+			foreach( Menu menu in menus )
+			{
+				var date = DateTime.ParseExact( menu.Date, "yyyyMMdd", CultureInfo.InvariantCulture );
+				response += $"On *{date:dd.MM.yyyy}* the meals are:{Environment.NewLine}{menu}{Environment.NewLine}{Environment.NewLine}";
+			}
+
+			return response.Trim();
+		}
+	}
+}


### PR DESCRIPTION
The command can be used to query the meals of future menus. The found
menus will be printed. If more than 10 menus would be returned, a notice
will be returned to be more precise when querying.